### PR TITLE
Comments:

### DIFF
--- a/BitArray.js
+++ b/BitArray.js
@@ -2,8 +2,8 @@ export default class BitArray extends DataView {
 	constructor(sizeOrBuffer) {
 		let len = 0;
 		if (sizeOrBuffer instanceof ArrayBuffer) {
-			len = sizeOrBuffer.byteLength * 8;
 			super(sizeOrBuffer);
+      len = sizeOrBuffer.byteLength * 8;
 		} else if (Number.isInteger(sizeOrBuffer)) {
 			if (sizeOrBuffer > 0x03ff000000) { throw new Error("BitArray size can not exceed 17163091968"); }
 			super(new ArrayBuffer(Number((BigInt(sizeOrBuffer + 31) & ~31n) >> 3n))); // Sets ArrayBuffer.byteLength to multiples of 4 bytes (32 bits)));
@@ -21,13 +21,13 @@ export default class BitArray extends DataView {
                          );
 	}
 
-	get popcount(){
-		let m1  = 0x55555555;
-		let m2  = 0x33333333;
-		let m4  = 0x0f0f0f0f;
-		let h01 = 0x01010101;
-		let pc  = 0;
-		let x;
+	get popcnt(){
+		let m1  = 0x55555555,
+		    m2  = 0x33333333,
+		    m4  = 0x0f0f0f0f,
+		    h01 = 0x01010101,
+		    pc  = 0,
+		    x;
 
 		for (let i = 0; i < this.buffer.byteLength; i++){
 			 x = this.getUint8(i);
@@ -38,6 +38,14 @@ export default class BitArray extends DataView {
 		}
 		return pc;
 	}
+
+  all(){
+  // Returns true if all bits in the BitArray are set.
+    let len = this.buffer.byteLength,
+        res = true;
+    for (var i = 0; res && i < len; i += 4) res = this.getUint32(i) === 0xffffffff;
+    return res;
+  }
 
   and(bar, inPlace = false){
   // And of this and bar. Example: 1100 & 1001 = 1000
@@ -63,14 +71,6 @@ export default class BitArray extends DataView {
   clear(){
   // Resets the BitArray in place
     for (let i = 0, len = this.buffer.byteLength; i < len; i += 4) this.setUint32(i,0);
-  }
-
-  every(){
-  // Returns true if all bits in the BitArray are set.
-    let len = this.buffer.byteLength,
-        res = true;
-    for (var i = 0; res && i < len; i += 4) res = this.getUint32(i) === 0xffffffff;
-    return res;
   }
 
   fill(){

--- a/BitArray.js
+++ b/BitArray.js
@@ -4,20 +4,21 @@ export default class BitArray extends DataView {
 		if (sizeOrBuffer instanceof ArrayBuffer) {
 			len = sizeOrBuffer.byteLength * 8;
 			super(sizeOrBuffer);
-		} else if (typeof sizeOrBuffer == "number") {
-			if (sizeOrBuffer > 1.5e10) { throw new Error("BitArray size can not exceed 1.5e10"); }
-			len = sizeOrBuffer;
-			super(new ArrayBuffer(Math.ceil(sizeOrBuffer/8)));
+		} else if (Number.isInteger(sizeOrBuffer)) {
+			if (sizeOrBuffer > 0x03ff000000) { throw new Error("BitArray size can not exceed 17163091968"); }
+			super(new ArrayBuffer(Number((BigInt(sizeOrBuffer + 31) & ~31n) >> 3n))); // Sets ArrayBuffer.byteLength to multiples of 4 bytes (32 bits)));
+      len = this.buffer.byteLength * 8;
 		} else {
-			throw new Error("A size or buffer must be provided when initalizing a BitArray");
+			throw new Error("An integer size or buffer must be provided when initalizing a BitArray");
 		}
-
-		Object.defineProperty(this, "length", {
-			configurable: false,
-			enumerable: false,
-			writable: false,
-			value: len
-		});
+    Object.defineProperty( this
+                         , "length"
+                         , { configurable: false
+                           , enumerable  : false
+                           , writable    : false
+                           , value       : len
+  	                       }
+                         );
 	}
 
 	get popcount(){
@@ -38,98 +39,94 @@ export default class BitArray extends DataView {
 		return pc;
 	}
 
-	at(i) {
-		// Fetches the value at the given index
-		if (i >= 0 && i < this.buffer.byteLength*8) {
-			return this.getUint8(i >> 3) & (1 << (i & 7)) ? 1 : 0;
-		}
-		return 0;
-	}
+  and(bar, inPlace = false){
+  // And of this and bar. Example: 1100 & 1001 = 1000
+    let len = Math.min(this.buffer.byteLength,bar.buffer.byteLength),
+        res = inPlace ? this : new BitArray(len * 8);
+    for (var i = 0; i < len; i += 4) res.setUint32(i,this.getUint32(i) & bar.getUint32(i));
+    return res;
+  }
 
-	set(i, bool = true) {
-		// Sets the value at the given index to the provided boolean
-		if (i >= 0 && i < this.buffer.byteLength*8) {
-			this.setUint8(i >> 3, this.getUint8(i >> 3) | (bool << (i & 7)));
-		}
-	}
+  any(){
+  // Returns true if any of the bits in the BitArray are set. If returns false then all bits are 0
+    let len = this.buffer.byteLength,
+        res = true;
+    for (var i = 0; res && i < len; i += 4) res = this.getUint32(i) === 0;
+    return !res;
+  }
 
-	reset(i) {
-		// Sets the value at the given index to 0
-		if (i >= 0 && i < this.buffer.byteLength*8) {
-			this.setUint8(i >> 3, this.getUint8(i >> 3) & ~(1 << (i & 7)));
-		}
-	}
+  at(n){
+  // Fetches the value at the given index
+    return this.getUint8(n / 8) & (1 << (n & 7)) ? 1 : 0;
+  }
 
-	setAll(bool = false) {
-		// Sets all values to the provided boolean value (like zeroing the array);
-		for (let i = 0; i < this.buffer.byteLength; i++) {
-			this.setUint8(i, bool ? 255 : 0);
-		}
-	}
+  clear(){
+  // Resets the BitArray in place
+    for (let i = 0, len = this.buffer.byteLength; i < len; i += 4) this.setUint32(i,0);
+  }
 
-	toggle(i) {
-		// Flips the value at the given index
-		if (i >= 0 && i < this.buffer.byteLength*8) {
-			this.setUint8(i >> 3, this.getUint8(i >> 3) ^ (1 << (i & 7)));
-		}
-	}
+  every(){
+  // Returns true if all bits in the BitArray are set.
+    let len = this.buffer.byteLength,
+        res = true;
+    for (var i = 0; res && i < len; i += 4) res = this.getUint32(i) === 0xffffffff;
+    return res;
+  }
 
-	slice(a = 0, b = this.length) {
-		return new BitArray(b-a,this.buffer.slice(a >> 3, b >> 3));
-	}
+  fill(){
+  // Sets the BitArray in place
+    for (let i = 0, len = this.buffer.byteLength; i < len; i += 4) this.setUint32(i,0xffffffff);
+  }
 
-	toString() {
-		let msg = [];
-		for (let i = 0; i < this.length; i++) {
-			msg.push(this.at(i));
-		}
-		return msg.join('');
-	}
+  not(){
+  // Flips all the bits in this buffer. Example: 1100 = 0011
+    let len = this.buffer.byteLength,
+    res = new BitArray(len * 8);
+    for (var i = 0; i < len; i += 4) res.setUint32(i,~(this.getUint32(i) >>> 0));
+    return res;
+  }
 
-	and(bar, newArray = false) {
-		// And of this and bar.  Example: 1100 & 1001 = 1000
-		let result = newArray ? new BitArray(this.length) : this;
-		for (let i = 0; i < this.buffer.byteLength; i++) {
-			result.setUint8(i, this.getUint8(i) & (i < bar.buffer.byteLength ? bar.getUint8(i) : 0));
-		}
-		return result;
-	}
-	
-	or(bar, newArray = false) {
-		// Or of this and bar.  Example: 1100 & 1001 = 1101
-		let len = Math.min(this.buffer.byteLength, bar.buffer.byteLength);
-		let result = newArray ? new BitArray(this.length) : this;
-		for (let i = 0; i < len; i++) {
-			result.setUint8(i, this.getUint8(i) | bar.getUint8(i));
-		}
-		return result;
-	}
+  or(bar, inPlace = false){
+  // Or of this and bar. Example: 1100 & 1001 = 1101
+    let len = Math.min(this.buffer.byteLength,bar.buffer.byteLength),
+    res = inPlace ? this : new BitArray(len * 8);
+    for (var i = 0; i < len; i += 4) res.setUint32(i,this.getUint32(i) | bar.getUint32(i));
+    return res;
+  }
 
-	xor(bar, newArray = false) {
-		// Xor of this and bar.  Example: 1100 & 1001 = 0101;
-		let len = Math.min(this.buffer.byteLength, bar.buffer.byteLength);
-		let result = new BitArray(this.length);
-		for (let i = 0; i < len; i++) {
-			result.setUint8(i, this.getUint8(i) ^ bar.getUint8(i));
-		}
-		return result;
-	}
-	
-	not(newArray = false) {
-		// Flips all the bits in this buffer.  Example: 1100 = 0011
-		let result = newArray ? new BitArray(this.length) : this;
-		for (let i = 0; i < this.buffer.byteLength; i++) {
-			result.setUint8(i, ~(this.getUint8(i) >> 0));
-		}
-		return result;
-	}
+  reset(i){
+	// Resets the value at the given index.
+    this.setUint8(i / 8, this.getUint8(i / 8) & ~(1 << (i & 7)));
+  }
 
-	clone() {
-		// Copies the values from this BitArray into a new BitArray
-		let result = new BitArray(this.length);
-		for (let i = 0; i < this.buffer.byteLength; i++) {
-			result.setUint8(i, this.getUint8(i));
-		}
-		return result;
-	}
+  set(i){
+	// Sets the value at the given index.
+    this.setUint8(i / 8, this.getUint8(i / 8) | (1 << (i & 7)));
+  }
+
+  slice(a = 0, b = this.buffer.byteLength){
+  // Slices BitArray and returns a new BitArray with buffer byteLength in multiples of 4 bytes (32 bits)
+  // The default argument values instantiate a clone.
+    b = a + Number((BigInt(b - a + 31) & ~31n));
+    return new BitArray(this.buffer.slice(a, b));
+  }
+
+  toggle(n){
+	// Flips the value at the given index
+    this.setUint8(n / 8, this.getUint8(n / 8) ^ (1 << (n & 7)));
+  }
+
+  // For efficiency maps this.buffer to an Uint8Array and byte by byte reverses the rank of bits and stringifies by
+  // reducing. However stringifying a huge BitArray is meaningless. Perhaps limiting the string size to 128 is reasonable.
+  toString(){
+    return new Uint8Array(this.buffer).reduce((p,c) => p + ((BigInt(c)* 0x0202020202n & 0x010884422010n) % 1023n).toString(2).padStart(8,"0"),"");
+  }
+
+  xor(bar, inPlace = false){
+	// Xor of this and bar. Example: 1100 & 1001 = 0101;
+    let len = Math.min(this.buffer.byteLength,bar.buffer.byteLength),
+    res = inPlace ? this : new BitArray(len * 8);
+    for (var i = 0; i < len; i += 4) res.setUint32(i,this.getUint32(i) ^ bar.getUint32(i));
+    return res;
+  }
 }

--- a/BitArray.js
+++ b/BitArray.js
@@ -55,9 +55,9 @@ export default class BitArray extends DataView {
     return !res;
   }
 
-  at(n){
+  at(i){
   // Fetches the value at the given index
-    return this.getUint8(n / 8) & (1 << (n & 7)) ? 1 : 0;
+    return this.getUint8(i / 8) & (1 << (i & 7)) ? 1 : 0;
   }
 
   clear(){
@@ -78,10 +78,10 @@ export default class BitArray extends DataView {
     for (let i = 0, len = this.buffer.byteLength; i < len; i += 4) this.setUint32(i,0xffffffff);
   }
 
-  not(){
+  not(inPlace = false){
   // Flips all the bits in this buffer. Example: 1100 = 0011
     let len = this.buffer.byteLength,
-    res = new BitArray(len * 8);
+    res = inPlace ? this : new BitArray(len * 8);
     for (var i = 0; i < len; i += 4) res.setUint32(i,~(this.getUint32(i) >>> 0));
     return res;
   }
@@ -111,9 +111,9 @@ export default class BitArray extends DataView {
     return new BitArray(this.buffer.slice(a, b));
   }
 
-  toggle(n){
+  toggle(i){
 	// Flips the value at the given index
-    this.setUint8(n / 8, this.getUint8(n / 8) ^ (1 << (n & 7)));
+    this.setUint8(i / 8, this.getUint8(i / 8) ^ (1 << (n & 7)));
   }
 
   // For efficiency maps this.buffer to an Uint8Array and byte by byte reverses the rank of bits and stringifies by

--- a/BitArray.js
+++ b/BitArray.js
@@ -29,12 +29,12 @@ export default class BitArray extends DataView {
 		    pc  = 0,
 		    x;
 
-		for (let i = 0; i < this.buffer.byteLength; i++){
-			 x = this.getUint8(i);
+		for (let i = 0; i < this.buffer.byteLength; i += 4)
+			 x = this.getUint32(i);
 			 x -= (x >> 1) & m1;             //put count of each 2 bits into those 2 bits
 			 x = (x & m2) + ((x >> 2) & m2); //put count of each 4 bits into those 4 bits
 			 x = (x + (x >> 4)) & m4;        //put count of each 8 bits into those 8 bits
-			 pc += (x * h01) >> 56;
+			 pc += (x * h01) >> 24;
 		}
 		return pc;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "JSBitArray",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Comments:
- **constructor**: Overloading the arguments with types is not elegant but let's leave it as is for the time being. The main reason behind extending the `DataView` object is, it's flexibility to access the underlying `ArrayBuffer` in both 8 bits and 32 bits at one go. If we use only 8 bits then we could have simply extended the `Uint8Array` object. So I changed the buffer back to multiples of 32 bits (4 bytes) as when performance is considered this is essential for 32 bit access for certain lot operations like `.and()`, `.every()` etc. Having said that we could still do 32 bit access in arbitrary length buffers up until the remaining part is no more 32 bits and then switch to 8 bit access. However all such calculations overload the code and dramatically slow it down for no good reason. In the worst case the additional 3 bytes is negligable in terms of memory footprint considering the performance gain. What's wrong with `BitArray` being in sizes multiples of 32 and why would one need a `BitArray` in size like 21 or 47? Besides with this structure one can extent `BitArray` to implement `BitVector128`, `BitVector256` or `BitVector512` objects with their own `shiftRight`, `shiftLeft` etc methods.
- **popcount**   : Works just fine. It counts the bits in a single byte. Can be renamed to `popcnt` though.

Modifications:
- **constructor** : Although it might depend on the JS engine and the hardware employed, I tried to increase the limit of the maximum `BitArray` size to be `0x03ff000000`. Which seems to be OK at least on my computer.
- **and** : Renamed the `newArray` boolean argument to `inPlace` which defaults to `false`. Changed to 32 bit access for performance.
- **at** : Removed index check which is very costly. `.at()` could be a very busy method and depending on the task may get invoked millions of times per task. It's best to leave the responsibility of entering proper index value to the user.
- **not** : Changed to 32 bit access for performance.
- **or** : Same as `.and()`.
- **set** : Removed index check. Also modified to only set a bit. Use `.reset()` instead to reset a bit. Also this avoids unnecessary type coercion.
- **slice** : Was broken. The unit of `.slice()` is now bytes. Also trying to slice in arbitrary `byteLength`s now returns a `BitArray` with closest `buffer.byteLength` in multiples of 32 bits startting from the first parameter (`a`) inclusive.
- **toggle** : Same as `.and()`.
- **toString** : Each stored byte is in reverse order such as `.set(0)` would result `00000001` to be stored at first byte of the `BitArray`. Accordingly bits in a byte get their ranks reversed before stringifying.
- **xor** : Changed to 32 bit access for performance.

New Features:
- **any** : Returns `true` if any of the bits in the `BitArray` are set. If returns `false` then all bits are 0.
- **clear** : Resets the `BitArray` in place
- **every** : Returns `true` if all bits in the `BitArray` are set.
- **fill** : Sets the `BitArray` in place.
- **reset** : Resets a bit at specified index position.

TODO:
- Once `BitArray` gets mature enough then it might be a good idea to rephrase it's heavy parts (or even completely) into AssembyScript (which is almost TypeScript) and compile for Web Assembly for stellar performance.
- `BitArray` can be further extended to implement fixed sized objects like `BitVector128`, `BitVector 256` etc.